### PR TITLE
Trigger workflow on deployment instead of push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Build & Deploy
 
 on:
-  push:
-    branches: master
+  deployment
 
 jobs:
   build:
@@ -33,3 +32,13 @@ jobs:
           app-name: actions-cake-demo
           package: artifacts/wwwroot.zip
           publish-profile: ${{ secrets.azureWebAppPublishProfile }}
+
+      - name: Finish Deployment
+        uses: bobheadxi/deployments@v0.1.0
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env_url: ${{ github.event.repository.homepage }}
+          deployment_id: ${{ github.event.deployment.id }}
+          status: ${{ job.status }}


### PR DESCRIPTION
This change makes the workflow react to a new [github deployment](https://developer.github.com/v3/repos/deployments/) instead of a push to master. Deployments will be created in slack using the command `/github deploy xt0rted/actions-cake-demo` which will ask what branch/commit should be deployed and then initiate the deployment. From there this workflow will start and do a build, then deploy to azure, and finally update the deployment status.