### PR TITLE
Use sdk version from global.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.300
 
       - name: Build Site
         run: ./build.ps1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
           app-name: actions-cake-demo
           package: artifacts/wwwroot.zip
           publish-profile: ${{ secrets.azureWebAppPublishProfile }}
+          slot-name: staging
 
       - name: Finish Deployment
         uses: bobheadxi/deployments@v0.4.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.300
 
       - name: Build Site
         run: ./build.ps1


### PR DESCRIPTION
As of v1.5.0 of the setup-dotnet action if you don't specify a version it'll check for one in the global.json